### PR TITLE
Update 2014-04-19-html-lankar.md

### DIFF
--- a/webbdesign/_posts/2014-04-19-html-lankar.md
+++ b/webbdesign/_posts/2014-04-19-html-lankar.md
@@ -41,7 +41,7 @@ Om du vill att länken ska öppna sidan i ett nytt fönster lägger du till ``ta
 Om sidan som du ska länka till inte ligger i samma mapp som länken så räcker det inte att skriva sida.html som adress, utan du blir tvungen att skriva vilken mapp den ligger i.
 {% highlight html %}
 
-<a href="/undermapp/sida.html">Länk</a> <!-- Länka till undermapp -->
+<a href="undermapp/sida.html">Länk</a> <!-- Länka till undermapp -->
 
 <a href="../sida.html">Länk</a> <!-- Länka till övermapp -->
 


### PR DESCRIPTION
tar bort /undermapp/sida.html det fungerar visst inte att länka så, undermapp/sida.html går mycket bättre
